### PR TITLE
fix: make sha command working 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/dvjn/woodpecker-docker-tags-plugin
+            ghcr.io/${{ github.repository_owner }}/woodpecker-docker-tags-plugin
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -197,6 +197,7 @@ handle_sha() {
       ;;
     -p | --prefix)
       prefix="$2"
+      shift
       ;;
     *)
       echo "Invalid option '$1'." >&2


### PR DESCRIPTION
There was missing `shift` in `sha` command.  Added.

I've also updated .github/actions to use `$github.repository_owner` repository  to make testbuild possible for MR authors.